### PR TITLE
create-model-fns takes a list of fn keywords to override defaults.

### DIFF
--- a/src/datomico/core.clj
+++ b/src/datomico/core.clj
@@ -72,7 +72,7 @@ datomic's error message: 'Unable to resolve entity: :db.type/'..."
       :db.install/_attribute :db.part/db}
      (remove #(nil? (val %)))
      (into {}))))
-    
+
 (defn build-schema
   "Given a keyword namespace and a vector of vectors, creates a schema as
   described at http://docs.datomic.com/schema.html. Each subvector represents an
@@ -110,14 +110,11 @@ datomic's error message: 'Unable to resolve entity: :db.type/'..."
 (def expand-ref datomico.model/expand-ref)
 (def delete datomico.action/delete)
 
-; TODO: allow user to pass in which fns they want to create
 (defmacro create-model-fns
-  "Creates model fns that are scoped to the given model (keyword namespace). Creates the following
-  fns: create, update, delete-all, find-all and find-first."
-  [nsp]
-  `(do
-    (dm/create-model-fn :create ~nsp)
-    (dm/create-model-fn :find-first ~nsp)
-    (dm/create-model-fn :find-all ~nsp)
-    (dm/create-model-fn :delete-all ~nsp)
-    (dm/create-model-fn :update ~nsp)))
+  "Creates model fns that are scoped to the given model (keyword
+  namespace). Creates the following fns by default: create, update,
+  delete-all, find-all and find-first. A list of keywords representing
+  functions to create can optionally be provided."
+  [nsp & [fns]]
+  (let [fns (if (nil? fns) [:create :update :delete-all :find-all :find-first] fns)]
+    `(do ~@(map (fn [name] `(dm/create-model-fn ~name ~nsp)) fns))))

--- a/src/datomico/db.clj
+++ b/src/datomico/db.clj
@@ -5,7 +5,7 @@
 (def ^{:dynamic true :doc "Datomic uri available to all datomico fns."} *uri*)
 (def ^{:dynamic true :doc "Datomic connection available to all datomico fns."} *connection*)
 (def ^{:dynamic true :doc "Datomic database value available to all datomico fns."} *db*)
-(def ^ {:dynamic true :doc "Determines whether to log transactions and queries."} *logging* false)
+(def ^{:dynamic true :doc "Determines whether to log transactions and queries."} *logging* false)
 
 ; from https://gist.github.com/3150938
 (defn wrap-datomic


### PR DESCRIPTION
I needed to be able to specify the list of functions to create via create-model-fns, then saw your comment in core.clj, so here you go. :) 
